### PR TITLE
Add pickling support for textparser.ParseError

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.9]
+        python-version: [3.8, 3.13]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Test
@@ -28,11 +28,11 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+      uses: actions/checkout@v4
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.13
     - name: Install pypa/build
       run: |
         python -m pip install build --user

--- a/tests/test_textparser.py
+++ b/tests/test_textparser.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 from collections import namedtuple
 
@@ -1114,6 +1115,21 @@ class TextParserTest(unittest.TestCase):
                              ],
                              '}',
                              ';'])
+
+    def test_error_picklable(self):
+        class Parser(textparser.Parser):
+
+            def grammar(self):
+                return Sequence('__EOF__')
+
+        try:
+            Parser().parse('123', match_sof=True)
+        except Exception as exc:
+            self.assertIsInstance(exc, textparser.ParseError)
+            pickled = pickle.dumps(exc)
+            unpickled = pickle.loads(pickled)
+            self.assertIsInstance(unpickled, textparser.ParseError)
+            self.assertEqual(repr(unpickled), repr(exc))
 
 
 if __name__ == '__main__':

--- a/textparser.py
+++ b/textparser.py
@@ -219,6 +219,10 @@ class ParseError(Error):
 
         return self._column
 
+    def __reduce__(self):
+        """Adds pickling support."""
+        return type(self), (self._text, self._offset), {}
+
 
 Token = namedtuple('Token', ['kind', 'value', 'offset'])
 


### PR DESCRIPTION
@eerimoq i want to load a cantools database in a ProcessPoolExecutor, but the missing pickling support causes a BrokenProcessPool, if a parsing error occurs.