### PR TITLE
GH actions: fix  version gh-action-pypi-publish

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -41,7 +41,7 @@ jobs:
         git clean -dfx
         python -m build --sdist --wheel --outdir dist/ .
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         skip_existing: true
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
it seems like using `@master` is no longer supported and `release/v1` must be used. this prevented new releases to be automatically uploaded to pypi.