### PR TITLE
update the required python version

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8, 3.13]
+        python-version: ['3.10', '3.14']
 
     steps:
     - uses: actions/checkout@v4
@@ -29,10 +29,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Set up Python 3.13
+    - name: Set up Python 3.14
       uses: actions/setup-python@v5
       with:
-        python-version: 3.13
+        python-version: 3.14
     - name: Install pypa/build
       run: |
         python -m pip install build --user

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from setuptools import setup
 from setuptools import find_packages
@@ -20,10 +20,10 @@ setup(name='textparser',
       license='MIT',
       classifiers=[
           'License :: OSI Approved :: MIT License',
-          'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 3',
       ],
       keywords=['parser', 'parsing'],
       url='https://github.com/eerimoq/textparser',
       py_modules=['textparser'],
+      python_requires='>=3.10',
       test_suite="tests")


### PR DESCRIPTION
This properly raises the minimum python version to 3.10. This is a prerequisite for #6:

- drop Python2 classifier (`setup.py`)
- specify python 3.10 as minimum python version (`setup.py`)
- update github action config file to use python 3.10 and 3.14